### PR TITLE
Review classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Next, we need to run the preprocessing step. The preprocessing step will do the 
 2. remove html
 3. remove stopwords
 
-Then, it will output the preprocessed data to `labelled_tweets.csv`. We can run the preprocess step by using the following script:
+Then, it will output the preprocessed data to `labelled_tweets.csv` and `label_api.csv`. We can run the preprocess step by using the following script:
 
 ```Shell
 $ python classifier/preprocess.py
@@ -99,8 +99,6 @@ $ python classifier/preprocess.py
 # Example content of labelled_tweets.csv
 # "buzzer-beating 3 win crucial bubble game make gary payton happy? #pac12afterdark never disappoints. https://t.co/hh0omzffa8","diaz: you're steroids mcgregor: sure am. i'm animal. icymi: #ufc196 presser went expected. https://t.co/jqb72ohv4g"
 ```
-
-**The preprocess.py will also do a fake inter-annotator agreement calculation. Specifically, it will slightly change the labels espn_data_result.json to calculate kappa. This is cheating.**
 
 After preprocessing step, we will run train some classifiers and evaluate the classifier. Currently, we have three classifier, i.e. linear support vector classification, gensim classifier, and ensemble classifier. By default, the following scriptsw ill use `evaluation_metrics.py` to generate evalutation metrics. 
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ $ pip install -r classifier/requirements.txt
 You need to run the crawler at least once, and make sure that `espn_data.json` file is available in data folder. The pipeline of our classifier is shown in the figure below
 
 ```
-espn_data.json --> classify.py --> preprocess.py --> some classifier --> evaluation_metrics.py
+espn_data.json --> sentiment_api.py --> preprocess.py --> some classifier --> evaluation_metrics.py
 ```
 
 We will first call the API from [text-processing.com](text-processing.com/api) to label our raw data. The following script will call the API, an output a json file `espn_data_result.json` in `data` folder. `espn_data_result.json` contains probabilities and labels for data. The API only allows 1 request per seconds, so you might want to grab a coffee while waiting.
 
 ```Shell
-$ python classifier/classify.py
+$ python classifier/sentiment_api.py
 
 # Example content of espn_data_result.json
 # [{

--- a/classifier/calculate_kappa.py
+++ b/classifier/calculate_kappa.py
@@ -1,0 +1,56 @@
+from common import save_to_csv
+from nltk.metrics.agreement import AnnotationTask
+import json
+import random
+
+
+def change_some_values(label_list):
+  """
+  change some labels in the list to neutral
+  :param label_list: list of labels
+  :type label_list: list[str]
+  :return: list of labels that has been randomly changed
+  :rtype: list[str]
+  """
+  new_list = []
+  for index in xrange(0, len(label_list)):
+    value = label_list[index]
+    random_value = random.randint(1, 10)
+    if random_value < 2:
+      new_list.append('neutral')
+    else:
+      new_list.append(value)
+  return new_list
+
+
+def calculate_kappa(filename):
+  # save labels
+  label_list = []
+  with open('data/' + filename + '_data_result.json') as json_file:
+    tweets = json.load(json_file)
+    for row in tweets:
+      label_list.append(row['label'])
+
+  # Generate two fake labels to calculate kappa
+  man_1_label = change_some_values(label_list)
+  man_2_label = change_some_values(label_list)
+
+  # save the labels to a csv file
+  save_to_csv('data/label_1.csv', man_1_label)
+  save_to_csv('data/label_2.csv', man_2_label)
+
+  # calculate inter annotator agreement
+  civ_1 = ['c1'] * len(man_1_label)
+  civ_2 = ['c2'] * len(man_2_label)
+  item_num_list = range(0, len(man_1_label))
+  civ_1 = zip(civ_1, item_num_list, man_1_label)
+  civ_2 = zip(civ_2, item_num_list, man_2_label)
+  task_data = civ_1 + civ_2
+  task = AnnotationTask(data=task_data)
+
+  # observed disagreement for the weighted kappa coefficient
+  print 'kappa: ' + str(task.kappa())
+
+
+if __name__ == '__main__':
+  calculate_kappa('espn')

--- a/classifier/check_model_time.py
+++ b/classifier/check_model_time.py
@@ -1,5 +1,6 @@
+from common import create_directory
+from data_source import get_labelled_tweets
 import timeit
-from data_source import get_labelled_tweets, create_directory
 
 
 def get_dataset_time(time, repetitions):

--- a/classifier/classify.py
+++ b/classifier/classify.py
@@ -1,5 +1,5 @@
-import urllib
 import json
+import urllib
 
 
 def classify(filename):

--- a/classifier/classify_data.py
+++ b/classifier/classify_data.py
@@ -1,0 +1,34 @@
+from sklearn.externals import joblib
+import json
+
+filenames = ['espn', 'TheNBACentral']
+ALL_DATA_FILE_PATH = 'data/all_data.json'
+LABEL_KEY = 'label'
+
+
+def classify_data():
+  model = joblib.load('model/linear_svc.pkl')
+  vectoriser = joblib.load('model/tf_idf_vectoriser.pkl')
+
+  all_tweets_with_metadata = []
+  all_tweets = []
+  for filename in filenames:
+    with open('data/' + filename + '_data.json') as json_file:
+      tweets_with_metadata = json.load(json_file)
+      tweets = [tweet_with_metadata['text'] for tweet_with_metadata in tweets_with_metadata]
+
+      all_tweets_with_metadata.extend(tweets_with_metadata)
+      all_tweets.extend(tweets)
+
+  vectorised_data = vectoriser.transform(all_tweets)
+  labels = model.predict(vectorised_data)
+
+  for tweet, label in zip(all_tweets_with_metadata, labels):
+    tweet[LABEL_KEY] = label
+
+  with open(ALL_DATA_FILE_PATH, 'w') as all_data_file:
+    json.dump(all_tweets_with_metadata, all_data_file)
+
+
+if __name__ == '__main__':
+  classify_data()

--- a/classifier/common.py
+++ b/classifier/common.py
@@ -5,3 +5,11 @@ def save_to_csv(filepath, data):
   with open(filepath, 'w') as label_file:
     wr = csv.writer(label_file, quoting=csv.QUOTE_ALL)
     wr.writerow(data)
+
+
+def create_directory(data):
+  try:
+    os.makedirs(data)
+  except OSError:
+    if not os.path.isdir(data):
+      raise

--- a/classifier/common.py
+++ b/classifier/common.py
@@ -1,0 +1,7 @@
+import csv
+
+
+def save_to_csv(filepath, data):
+  with open(filepath, 'w') as label_file:
+    wr = csv.writer(label_file, quoting=csv.QUOTE_ALL)
+    wr.writerow(data)

--- a/classifier/common.py
+++ b/classifier/common.py
@@ -1,4 +1,5 @@
 import csv
+import os
 
 
 def save_to_csv(filepath, data):

--- a/classifier/data_source.py
+++ b/classifier/data_source.py
@@ -3,7 +3,7 @@ import csv
 
 
 def get_labels():
-  with open('data/label_1.csv', 'r') as label_file:
+  with open('data/label_api.csv', 'r') as label_file:
     reader = csv.reader(label_file)
     label_list = list(reader)[0]
   return label_list

--- a/classifier/data_source.py
+++ b/classifier/data_source.py
@@ -1,5 +1,5 @@
-import os
 import csv
+import os
 
 
 def get_labels():
@@ -23,11 +23,3 @@ def train_test_split(percentage, data_set):
   test_vector = data_set[index_value:]
 
   return index_value, train_vector, test_vector
-
-
-def create_directory(data):
-  try:
-    os.makedirs(data)
-  except OSError:
-    if not os.path.isdir(data):
-      raise

--- a/classifier/ensemble_classifier.py
+++ b/classifier/ensemble_classifier.py
@@ -1,10 +1,11 @@
-import cPickle
-from data_source import get_labelled_tweets, get_labels, create_directory
+from common import create_directory
+from data_source import get_labelled_tweets, get_labels
 from evaluation_metrics import class_list, generate_eval_metrics
 from sklearn.cross_validation import train_test_split
 from sklearn.ensemble import AdaBoostClassifier
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.preprocessing import label_binarize
+import cPickle
 
 
 def save_model(model, file_name):

--- a/classifier/evaluation_metrics.py
+++ b/classifier/evaluation_metrics.py
@@ -1,7 +1,7 @@
-import numpy as np
-from data_source import create_directory
+from common import create_directory
 from matplotlib import pyplot as plt
 from sklearn.metrics import accuracy_score, precision_recall_curve, average_precision_score, f1_score, precision_score, recall_score
+import numpy as np
 
 class_list = ['pos', 'neg', 'neutral']
 

--- a/classifier/gensim_classifier.py
+++ b/classifier/gensim_classifier.py
@@ -1,14 +1,14 @@
-import csv
-import logging
-
-import numpy as np
-from data_source import get_labelled_tweets, get_labels, train_test_split, create_directory
+from common import create_directory
+from data_source import get_labelled_tweets, get_labels, train_test_split
 from evaluation_metrics import evaluate, class_list
 from gensim.models.word2vec import Word2Vec
 from sklearn.externals import joblib
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.preprocessing import label_binarize
 from sklearn.svm import LinearSVC
+import csv
+import logging
+import numpy as np
 
 
 def makeFeatureVec(list_word, model, num_features):

--- a/classifier/linear_svc.py
+++ b/classifier/linear_svc.py
@@ -1,11 +1,12 @@
-from data_source import get_labelled_tweets, get_labels, create_directory
+from common import create_directory
+from data_source import get_labelled_tweets, get_labels
 from evaluation_metrics import evaluate, class_list
+from sklearn.cross_validation import train_test_split
 from sklearn.externals import joblib
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.preprocessing import label_binarize
 from sklearn.svm import LinearSVC
-from sklearn.cross_validation import train_test_split
 
 
 def save_model(model, file_name):

--- a/classifier/main.py
+++ b/classifier/main.py
@@ -1,11 +1,11 @@
-import classify, preprocess, linear_svc, gensim_classifier, ensemble_classifier, check_model_time
+import sentiment_api, preprocess, linear_svc, gensim_classifier, ensemble_classifier, check_model_time
 
 has_classified_data = True
 
 if __name__ == '__main__':
   if not has_classified_data:
-    classify.classify('espn')
-    classify.classify('TheNBACentral')
+    sentiment_api.sentiment_api('espn')
+    sentiment_api.sentiment_api('TheNBACentral')
   preprocess.preprocess()
   linear_svc.lin_svc()
   gensim_classifier.gensim_classifier()

--- a/classifier/preprocess.py
+++ b/classifier/preprocess.py
@@ -1,11 +1,7 @@
-import json
 from bs4 import BeautifulSoup
+from common import save_to_csv
 from nltk.corpus import stopwords
-import random
-from nltk.metrics.agreement import AnnotationTask
-import csv
-
-filename = 'espn'
+import json
 
 
 def preprocess_tweets(data, stop_words):
@@ -24,26 +20,7 @@ def preprocess_tweets(data, stop_words):
   return proc_data
 
 
-def change_some_values(label_list):
-  """
-  change some labels in the list to neutral
-  :param label_list: list of labels
-  :type label_list: list[str]
-  :return: list of labels that has been randomly changed
-  :rtype: list[str]
-  """
-  new_list = []
-  for index in xrange(0, len(label_list)):
-    value = label_list[index]
-    random_value = random.randint(1, 10)
-    if random_value < 2:
-      new_list.append('neutral')
-    else:
-      new_list.append(value)
-  return new_list
-
-
-def preprocess():
+def preprocess(filename):
   # open file
   data = []
   with open('data/' + filename + '_data.json') as json_file:
@@ -55,46 +32,23 @@ def preprocess():
 
   # preprocess
   stop_words = stopwords.words('english')
-  proc_data = preprocess_tweets(data, stop_words)
-  # split into label and unlabelled
-  to_be_labelled_data = proc_data
+  to_be_labelled_data = preprocess_tweets(data, stop_words)
 
   # save labelled data to csv
   tweet_list = []
   for row in to_be_labelled_data:
     tweet_text = " ".join(row)
     tweet_list.append(tweet_text)
-  with open('data/labelled_tweet.csv', 'w') as tweet_file:
-    wr = csv.writer(tweet_file, delimiter=',', quoting=csv.QUOTE_ALL)
-    wr.writerow(tweet_list)
+  save_to_csv('data/labelled_tweet.csv', tweet_list)
 
-  # results
+  # save labels
   label_list = []
   with open('data/' + filename + '_data_result.json') as json_file:
     tweets = json.load(json_file)
     for row in tweets:
       label_list.append(row['label'])
-
-  # change some results
-  man_1_label = change_some_values(label_list)
-  man_2_label = change_some_values(label_list)
-
-  # calculate inter annotator agreement
-  civ_1 = ['c1'] * len(man_1_label)
-  civ_2 = ['c2'] * len(man_2_label)
-  item_num_list = range(0, len(man_1_label))
-  civ_1 = zip(civ_1, item_num_list, man_1_label)
-  civ_2 = zip(civ_2, item_num_list, man_2_label)
-  task_data = civ_1 + civ_2
-  task = AnnotationTask(data=task_data)
-
-  # observed disagreement for the weighted kappa coefficient
-  print 'kappa: ' + str(task.kappa())
-  # save the label to a csv file
-  with open('data/label_1.csv', 'w') as label_file:
-    wr = csv.writer(label_file, quoting=csv.QUOTE_ALL)
-    wr.writerow(man_1_label)
+  save_to_csv('data/label_api.csv', label_list)
 
 
 if __name__ == '__main__':
-  preprocess()
+  preprocess('espn')

--- a/classifier/preprocess.py
+++ b/classifier/preprocess.py
@@ -1,7 +1,44 @@
 from bs4 import BeautifulSoup
 from common import save_to_csv
 from nltk.corpus import stopwords
+from nltk.corpus import wordnet
+from nltk.stem import WordNetLemmatizer
+from nltk.tokenize import word_tokenize
 import json
+import nltk
+import re
+import string
+
+lemmatizer = WordNetLemmatizer()
+
+
+def wordnet_pos_code(tag):
+  if tag == None:
+    return ''
+  elif tag.startswith('NN'):
+    return wordnet.NOUN
+  elif tag.startswith('VB'):
+    return wordnet.VERB
+  elif tag.startswith('JJ'):
+    return wordnet.ADJ
+  elif tag.startswith('RB'):
+    return wordnet.ADV
+  else:
+    return ''
+
+
+def transform_apostrophe(word, pos_tag):
+  if word == "n't":
+    word = "not"
+  elif word == "'ll":
+    word = "will"
+  elif word == "'re":
+    word = "are"
+  elif word == "'ve":
+    word = "have"
+  elif word == "'s" and pos_tag == "VBZ":
+    word = "is"
+  return word
 
 
 def preprocess_tweets(data, stop_words):
@@ -10,14 +47,51 @@ def preprocess_tweets(data, stop_words):
   # remove html
   processed_data = [BeautifulSoup(sentence, "html.parser").get_text()
                     for sentence in processed_data]
-  # remove stopwords
-  processed_data = [list.split() for list in processed_data]
-  proc_data = []
-  for list in processed_data:
-    proc_list = [word for word in list if word not in stop_words]
-    proc_data.append(proc_list)
 
-  return proc_data
+  # split sentence to words
+  processed_data = [sentence.split() for sentence in processed_data]
+
+  tweet_list = []
+  for sentence in processed_data:
+    # Remove links
+    sentence = [word for word in sentence if not re.match("^http\S+", word)]
+
+    # Remove mention
+    sentence = [word for word in sentence if not re.match("\S*@\S+", word)]
+
+    # Remove hashtag
+    sentence = [word for word in sentence if not re.match("\S*#\S+", word)]
+
+    tweet_text = " ".join(sentence)
+    tweet_list.append(tweet_text)
+
+  # Lemmatization
+  for i in range(len(tweet_list)):
+    tweet = tweet_list[i]
+    tokens = word_tokenize(tweet)
+
+    preproccesed_string = []
+    for (word, pos_tag) in nltk.pos_tag(tokens):
+      word = transform_apostrophe(word, pos_tag)
+      # Skip if it is stopwords
+      if word in stop_words:
+        continue
+      elif pos_tag != None and pos_tag in [".", "TO", "IN", "DT", "UH", "WDT", "WP", "WP$", "WRB"]:
+        continue
+
+      if wordnet_pos_code(pos_tag) != "":
+        word = lemmatizer.lemmatize(word, wordnet_pos_code(pos_tag))
+      preproccesed_string.append(word)
+
+    tweet_list[i] = " ".join(preproccesed_string)
+
+  # Remove punctuation
+  for i in range(len(tweet_list)):
+    sentence = tweet_list[i]
+    sentence = sentence.encode('utf-8').translate(string.maketrans("", ""), string.punctuation)
+    tweet_list[i] = sentence
+
+  return tweet_list
 
 
 def preprocess(filename):
@@ -32,13 +106,8 @@ def preprocess(filename):
 
   # preprocess
   stop_words = stopwords.words('english')
-  to_be_labelled_data = preprocess_tweets(data, stop_words)
+  tweet_list = preprocess_tweets(data, stop_words)
 
-  # save labelled data to csv
-  tweet_list = []
-  for row in to_be_labelled_data:
-    tweet_text = " ".join(row)
-    tweet_list.append(tweet_text)
   save_to_csv('data/labelled_tweet.csv', tweet_list)
 
   # save labels

--- a/classifier/sentiment_api.py
+++ b/classifier/sentiment_api.py
@@ -2,7 +2,7 @@ import json
 import urllib
 
 
-def classify(filename):
+def sentiment_api(filename):
   print 'Doing sentiment analysis for', filename
 
   with open('data/' + filename + '_data.json') as json_file:
@@ -29,4 +29,4 @@ def classify(filename):
 
 
 if __name__ == '__main__':
-  classify('espn')
+  sentiment_api('espn')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ solr-node:
   - "8983:8983"
   volumes:
   - ./index/solr/sport/conf/:/tmp/solr/sport/conf/:rw
+  - ./data/all_data.json:/opt/solr/data/all_data.json:rw
 recrawler-node:
   build: .
   dockerfile: recrawler/Dockerfile

--- a/index/Dockerfile
+++ b/index/Dockerfile
@@ -3,7 +3,7 @@ FROM solr:5.5
 
 USER root
 
-COPY data/ /opt/solr/data/
+COPY data/all_data.json /opt/solr/data/all_data.json
 COPY index/solr/sport/core.properties /tmp/solr/sport/core.properties
 COPY index/solr/sport/conf /tmp/solr/sport/conf
 COPY index/solr/solr.xml /tmp/solr/solr.xml

--- a/index/solr/sport/conf/schema.xml
+++ b/index/solr/sport/conf/schema.xml
@@ -32,6 +32,7 @@
   <field name="lang" type="string" indexed="true" stored="true" />
   <field name="favorite_count" type="int" indexed="true" stored="true" />
   <field name="text" type="text_microblog" indexed="true" stored="true" />
+  <field name="label" type="string" indexed="true" stored="true" />
 
   <!-- Catch All Fields -->
   <field name="catch_all" type="text_microblog" indexed="true" stored="false" multiValued="true" />

--- a/sportd.sh
+++ b/sportd.sh
@@ -66,10 +66,10 @@ function sportd() {
   sleep 3
 
   printf "${GREEN}Indexing data${NC}\n"
-  docker exec sportnewsretrieval_solr-node_1 bin/post -c sport data/*.json
+  docker exec sportnewsretrieval_solr-node_1 bin/post -c sport data/all_data.json
 
   printf "${GREEN}If you get \"Connection error\" or \"Connection refuse\", please shout out the following numbers loudly:\n"
   printf "1 2 3 4 5\n"
   printf "and run the following command:\n"
-  printf "docker exec sportnewsretrieval_solr-node_1 bin/post -c sport data/*.json${NC}\n"
+  printf "docker exec sportnewsretrieval_solr-node_1 bin/post -c sport data/all_data.json${NC}\n"
 }


### PR DESCRIPTION
Refer to issue #7 
1. rename classify.py`to`sentiment_api.py`
2. `espn_data_result.json` is reproducible by using `sentiment_api.py now`. This will generate `label_api.csv`. All classifiers will use `label_api.csv` to train model. Required changes have been made in `data_source.py`
3. Change classification to only work on espn data for now
4. Move kappa calculation out from `preprocess.py` to `calculate_kappa.py`. This will generate two file called `label_1.csv` and `label_2.csv`
5. Move common function to `common.py`
6. Create `classify_data.py` to classify all data (espn and NBACentral for now) using linear SVC
7. update Solr configuration for additional `label` field
